### PR TITLE
Battery indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Weather precipitation graph using Lilygo T5 2.13" ESP32 E-paper screen. This pro
      - Modify the `USER_AGENT` if desired
      - Set `DEBUG` to `true` or `false` as needed
      - set `SHOW_GRAPH_ON_NO_PRECIPITATION` to liking
+     - set `SHOW_BATTERY_INDICATOR` to liking
 
 9. Select the correct board and port:
    - Go to Tools > Board and select "ESP32 Dev Module" or your specific Lilygo T5 board

--- a/example.config.h
+++ b/example.config.h
@@ -7,4 +7,7 @@
 // If false, the graph will be replaced with a message saying "Det blir opphald dei neste 90 minutta"
 #define SHOW_GRAPH_ON_NO_PRECIPITATION true
 
+#define BATTERY_MAX_VOLTAGE 4.2  // Charging voltage
+#define BATTERY_MIN_VOLTAGE 2.75 // Discharge voltage
+
 #endif // CONFIG_H

--- a/example.config.h
+++ b/example.config.h
@@ -10,4 +10,6 @@
 #define BATTERY_MAX_VOLTAGE 4.2  // Charging voltage
 #define BATTERY_MIN_VOLTAGE 2.75 // Discharge voltage
 
+#define SHOW_BATTERY_INDICATOR true
+
 #endif // CONFIG_H

--- a/yr-regn-display.ino
+++ b/yr-regn-display.ino
@@ -153,6 +153,8 @@ void updateDisplayWithNewData() {
                 drawNoPrecipitationView(display, createdTime);
             }
         }
+
+        drawBatteryIndicator(display, 110, 23);
     } while (display.nextPage());
 }
 
@@ -259,6 +261,55 @@ void checkButtonPressForReset(WiFiManager& wifiManager) {
                 wifiManager.resetSettings();
                 ESP.restart();
             }
+        }
+    }
+}
+
+float getBatteryVoltage() {
+    float voltage = analogRead(35) / 4096.0 * 7.46;
+    return voltage;
+}
+
+int getBatteryPercentage(float voltage) {
+    if (voltage >= BATTERY_MAX_VOLTAGE) return 100;
+    if (voltage <= BATTERY_MIN_VOLTAGE) return 0;
+    return (voltage - BATTERY_MIN_VOLTAGE) / (BATTERY_MAX_VOLTAGE - BATTERY_MIN_VOLTAGE) * 100;
+}
+
+void drawBatteryIndicator(DisplayType& display, int x, int y) {
+    float voltage = getBatteryVoltage();
+    display.setCursor(x, y);
+    display.setFont();
+
+    int percentage = getBatteryPercentage(voltage);
+    Serial.printf("Battery: %d%% (%.2fV)\n", percentage, voltage);
+
+    if (SHOW_BATTERY_AS_TEXT) {
+        display.print("Batt: ");
+        display.print(percentage);
+        display.print("% (");
+        display.print(voltage, 2);
+        display.print("V)");
+    } else {
+        // Battery outline
+        display.drawRect(x, y, 19, 8, GxEPD_BLACK);
+        display.fillRect(x + 19, y + 2, 2, 4, GxEPD_BLACK);
+
+        // Add text for battery percentage and voltage
+        display.setCursor(x + 24, y);
+        display.setTextSize(1);
+        display.print(percentage);
+        display.print("% (");
+        display.print(voltage, 1);
+        display.print("V)");
+
+        // Calculate battery level
+        int level = map(percentage, 0, 100, 0, 18);
+        display.fillRect(x + 1, y + 1, level, 6, GxEPD_BLACK);
+
+        // Battery level indicator lines
+        for (int i = 1; i <= 3; i++) {
+            display.drawFastVLine(x + 5 * i, y + 1, 6, GxEPD_BLACK);
         }
     }
 }

--- a/yr-regn-display.ino
+++ b/yr-regn-display.ino
@@ -154,7 +154,9 @@ void updateDisplayWithNewData() {
             }
         }
 
-        drawBatteryIndicator(display, 110, 23);
+        if (SHOW_BATTERY_INDICATOR) {
+            drawBatteryIndicator(display, 110, 23);
+        }
     } while (display.nextPage());
 }
 
@@ -284,32 +286,24 @@ void drawBatteryIndicator(DisplayType& display, int x, int y) {
     int percentage = getBatteryPercentage(voltage);
     Serial.printf("Battery: %d%% (%.2fV)\n", percentage, voltage);
 
-    if (SHOW_BATTERY_AS_TEXT) {
-        display.print("Batt: ");
-        display.print(percentage);
-        display.print("% (");
-        display.print(voltage, 2);
-        display.print("V)");
-    } else {
-        // Battery outline
-        display.drawRect(x, y, 19, 8, GxEPD_BLACK);
-        display.fillRect(x + 19, y + 2, 2, 4, GxEPD_BLACK);
+    // Battery outline
+    display.drawRect(x, y, 19, 8, GxEPD_BLACK);
+    display.fillRect(x + 19, y + 2, 2, 4, GxEPD_BLACK);
 
-        // Add text for battery percentage and voltage
-        display.setCursor(x + 24, y);
-        display.setTextSize(1);
-        display.print(percentage);
-        display.print("% (");
-        display.print(voltage, 1);
-        display.print("V)");
+    // Add text for battery percentage and voltage
+    display.setCursor(x + 24, y);
+    display.setTextSize(1);
+    display.print(percentage);
+    display.print("% (");
+    display.print(voltage, 1);
+    display.print("V)");
 
-        // Calculate battery level
-        int level = map(percentage, 0, 100, 0, 18);
-        display.fillRect(x + 1, y + 1, level, 6, GxEPD_BLACK);
+    // Calculate battery level
+    int level = map(percentage, 0, 100, 0, 18);
+    display.fillRect(x + 1, y + 1, level, 6, GxEPD_BLACK);
 
-        // Battery level indicator lines
-        for (int i = 1; i <= 3; i++) {
-            display.drawFastVLine(x + 5 * i, y + 1, 6, GxEPD_BLACK);
-        }
+    // Battery level indicator lines
+    for (int i = 1; i <= 3; i++) {
+        display.drawFastVLine(x + 5 * i, y + 1, 6, GxEPD_BLACK);
     }
 }


### PR DESCRIPTION
Adds Battery indicator display. 
based on https://github.com/Xinyuan-LilyGO/LilyGo-T5-Epaper-Series/issues/32#issuecomment-1341167760. Relatively accurate, but not spot on.

The indicator can be toggled on or of via the `SHOW_BATTERY_INDICATOR` config.h variable

<img width="450px" src="https://github.com/user-attachments/assets/f505d845-a8ac-44cf-9d5d-b8ead2f7da81">